### PR TITLE
feat: begin with gateway by adding maven deps and docker compose 

### DIFF
--- a/admin/src/main/resources/application.yaml
+++ b/admin/src/main/resources/application.yaml
@@ -1,6 +1,5 @@
 server:
   port: 8002
-
 spring:
   application:
     name: short-link-admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,30 @@
 version: '3.8'
 
 services:
-  # docker-compose up -d nacos
-  nacos:
-    image: nacos/nacos-server:latest
-    container_name: nacos
+  # docker-compose up -d  consul
+  consul:
+    image: hashicorp/consul:latest
+    container_name: consul
     ports:
-      - "8848:8848"
-    environment:
-      - MODE=standalone
-      - SPRING_DATASOURCE_PLATFORM=mysql
-      - MYSQL_SERVICE_HOST=mysql
-      - MYSQL_SERVICE_DB_NAME=link
-      - MYSQL_SERVICE_PORT=3306
-      - MYSQL_SERVICE_USER=admin
-      - MYSQL_SERVICE_PASSWORD=admin
-    volumes:
-      - ./nacos/logs:/home/nacos/logs
+      - "8500:8500"      # Consul UI & API Port
+      - "8600:8600/udp"  # Consul DNS  Port
+    command: "agent -dev -client=0.0.0.0"
     networks:
       - backend
+    restart: unless-stopped
+
+  # docker-compose up -d  envoy
+  envoy:
+    image: envoyproxy/envoy:v1.26.0
+    container_name: envoy
+    ports:
+      - "10000:10000"   # Ports that Envoy listens to, our services request can be sent through this port.
+    volumes:
+      - ./gateway/envoy.yaml:/etc/envoy/envoy.yaml:ro  # Envoy config YML file
+    networks:
+      - backend
+    depends_on:
+      - consul
     restart: unless-stopped
 
   mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,26 @@
 version: '3.8'
 
 services:
+  # docker-compose up -d nacos
+  nacos:
+    image: nacos/nacos-server:latest
+    container_name: nacos
+    ports:
+      - "8848:8848"
+    environment:
+      - MODE=standalone
+      - SPRING_DATASOURCE_PLATFORM=mysql
+      - MYSQL_SERVICE_HOST=mysql
+      - MYSQL_SERVICE_DB_NAME=link
+      - MYSQL_SERVICE_PORT=3306
+      - MYSQL_SERVICE_USER=admin
+      - MYSQL_SERVICE_PASSWORD=admin
+    volumes:
+      - ./nacos/logs:/home/nacos/logs
+    networks:
+      - backend
+    restart: unless-stopped
+
   mysql:
     image: mysql:8.0
     container_name: link-db

--- a/gateway/envoy.yaml
+++ b/gateway/envoy.yaml
@@ -1,0 +1,42 @@
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8000
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: example_cluster
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: example_cluster
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: example_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: www.example.com
+                      port_value: 80

--- a/gateway/envoy.yaml
+++ b/gateway/envoy.yaml
@@ -1,6 +1,6 @@
 static_resources:
   listeners:
-    - name: listener_0
+    - name: listener_gateway
       address:
         socket_address:
           address: 0.0.0.0
@@ -18,25 +18,45 @@ static_resources:
                       domains: ["*"]
                       routes:
                         - match:
-                            prefix: "/"
+                            prefix: "/api/short-link/project"
                           route:
-                            cluster: example_cluster
+                            cluster: project_cluster
+                        - match:
+                            prefix: "/api/short-link/admin"
+                          route:
+                            cluster: admin_cluster
                 http_filters:
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
-    - name: example_cluster
+    # Project cluster
+    - name: project_cluster
       connect_timeout: 0.25s
       type: STRICT_DNS
       lb_policy: ROUND_ROBIN
       load_assignment:
-        cluster_name: example_cluster
+        cluster_name: project_cluster
         endpoints:
           - lb_endpoints:
               - endpoint:
                   address:
                     socket_address:
-                      address: www.example.com
-                      port_value: 80
+                      address: project
+                      port_value: 8001
+
+    # Admin cluster
+    - name: admin_cluster
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: admin_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: admin
+                      port_value: 8002

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -9,4 +9,37 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>shortlink-gateway</artifactId>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-loadbalancer</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.fastjson2</groupId>
+            <artifactId>fastjson2</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -23,13 +23,13 @@
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-consul-discovery</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba.cloud</groupId>
-            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-consul-config</artifactId>
         </dependency>
 
         <dependency>

--- a/gateway/src/main/java/org/ucd/shortlink/gateway/GatewayServiceApplication.java
+++ b/gateway/src/main/java/org/ucd/shortlink/gateway/GatewayServiceApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ucd.shortlink.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Gateway service Spring Boot Starter
+ */
+
+@SpringBootApplication
+public class GatewayServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayServiceApplication.class, args);
+    }
+}

--- a/gateway/src/main/java/org/ucd/shortlink/gateway/config/Config.java
+++ b/gateway/src/main/java/org/ucd/shortlink/gateway/config/Config.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ucd.shortlink.gateway.config;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class Config {
+    /**
+     * Whitelist path collection
+     */
+    private List<String> whitePathList;
+}

--- a/gateway/src/main/java/org/ucd/shortlink/gateway/dto/GatewayErrorResult.java
+++ b/gateway/src/main/java/org/ucd/shortlink/gateway/dto/GatewayErrorResult.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ucd.shortlink.gateway.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Gateway error response message
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GatewayErrorResult {
+    /**
+     * HTTP Status Code
+     */
+    private Integer status;
+
+    /**
+     * Response message
+     */
+    private String message;
+}

--- a/gateway/src/main/java/org/ucd/shortlink/gateway/filter/TokenValidateGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/ucd/shortlink/gateway/filter/TokenValidateGatewayFilterFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ucd.shortlink.gateway.filter;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.ucd.shortlink.gateway.config.Config;
+import org.ucd.shortlink.gateway.dto.GatewayErrorResult;
+import reactor.core.publisher.Mono;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * SpringCloud Gateway Token Interceptor
+ */
+@Component
+public class TokenValidateGatewayFilterFactory extends AbstractGatewayFilterFactory<Config> {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public TokenValidateGatewayFilterFactory(StringRedisTemplate stringRedisTemplate) {
+        super(Config.class);
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+            String requestPath = request.getPath().toString();
+            String requestMethod = request.getMethod().name();
+            if (!isPathInWhiteList(requestPath, requestMethod, config.getWhitePathList())) {
+                String username = request.getHeaders().getFirst("username");
+                String token = request.getHeaders().getFirst("token");
+                Object userInfo;
+                if (StringUtils.hasText(username) && StringUtils.hasText(token)
+                        && (userInfo = stringRedisTemplate.opsForHash().get("short-link:login:" + username, token)) != null) {
+                    JSONObject userInfoJsonObj = JSON.parseObject(userInfo.toString());
+                    ServerHttpRequest.Builder httpRequestBuilder =
+                            exchange.getRequest().mutate().headers(header -> {
+                                header.set("userId", userInfoJsonObj.getString("id"));
+                                header.set("realName", URLEncoder.encode(userInfoJsonObj.getString("realName"), StandardCharsets.UTF_8));
+                            });
+                    return chain.filter(exchange.mutate().request(httpRequestBuilder.build()).build());
+                }
+                ServerHttpResponse response = exchange.getResponse();
+                response.setStatusCode(HttpStatus.UNAUTHORIZED);
+                return response.writeWith(Mono.fromSupplier(() -> {
+                    DataBufferFactory bufferFactory = response.bufferFactory();
+                    GatewayErrorResult resultMessage = GatewayErrorResult.builder()
+                            .status(HttpStatus.UNAUTHORIZED.value())
+                            .message("Token validation error")
+                            .build();
+                    return bufferFactory.wrap(JSON.toJSONString(resultMessage).getBytes());
+                }));
+            }
+            return chain.filter(exchange);
+        };
+    }
+
+    /**
+     * Function to check whether provided request path & request method
+     * locates in the collection of white path list
+     */
+    private boolean isPathInWhiteList(String requestPath, String requestMethod, List<String> whitePathList) {
+        return (!CollectionUtils.isEmpty(whitePathList) && whitePathList.stream().anyMatch(requestPath::startsWith)) || (Objects.equals(requestPath, "/api/short-link/admin/v1/user") && Objects.equals(requestMethod, "POST"));
+    }
+}

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -8,27 +8,3 @@ spring:
     redis:
       host: 127.0.0.1
       port: 6379
-      password: 123456
-  cloud:
-    nacos:
-      discovery:
-        server-addr: 127.0.0.1:8848
-    gateway:
-      routes:
-        - id: short-link-admin
-          uri: lb://short-link-admin/api/short-link/admin/**
-          predicates:
-            - Path=/api/short-link/admin/**
-          filters:
-            - name: TokenValidate
-              args:
-                whitePathList:
-                  - /api/short-link/admin/v1/user/login
-                  - /api/short-link/admin/v1/user/has-username
-
-        - id: short-link-project
-          uri: lb://short-link-project/api/short-link/**
-          predicates:
-            - Path=/api/short-link/**
-          filters:
-            - name: TokenValidate

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -4,6 +4,25 @@ server:
 spring:
   application:
     name: short-link-gateway
+  cloud:
+    gateway:
+      routes:
+        - id: admin_route
+          uri: http://localhost:8002  # Admin service URL
+          predicates:
+            - Path=/api/short-link/admin/**
+        - id: project_route
+          uri: http://localhost:8001  # Project service URL
+          predicates:
+            - Path=/api/short-link/project/**
+    consul:
+      host: 127.0.0.1
+      port: 8500
+      discovery:
+        service-name: shortlink-platform
+        register: true
+      config:
+        enabled: false
   data:
     redis:
       host: 127.0.0.1

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -1,2 +1,34 @@
 server:
   port: 8000
+
+spring:
+  application:
+    name: short-link-gateway
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+      password: 123456
+  cloud:
+    nacos:
+      discovery:
+        server-addr: 127.0.0.1:8848
+    gateway:
+      routes:
+        - id: short-link-admin
+          uri: lb://short-link-admin/api/short-link/admin/**
+          predicates:
+            - Path=/api/short-link/admin/**
+          filters:
+            - name: TokenValidate
+              args:
+                whitePathList:
+                  - /api/short-link/admin/v1/user/login
+                  - /api/short-link/admin/v1/user/has-username
+
+        - id: short-link-project
+          uri: lb://short-link-project/api/short-link/**
+          predicates:
+            - Path=/api/short-link/**
+          filters:
+            - name: TokenValidate

--- a/project/src/main/resources/application.yaml
+++ b/project/src/main/resources/application.yaml
@@ -1,6 +1,5 @@
 server:
   port: 8001
-
 spring:
   application:
     name: short-link-project


### PR DESCRIPTION
I initially tried to deploy Nacos via Docker Compose in my local environment. However, Nacos relies on an external database to execute schema initialization, import initial datasets, and maintain registered services by reading/writing to the database. In my opinion, it’s not a smart idea to depend on a business-level database for storing service discovery data.

I suspected that my setup problems were caused by my database sharding strategy, which led to Nacos failing during database schema creation and initial dataset injection.

Given our future plans to deploy the project to Kubernetes or other cloud provider platforms, I realized we would be facing endless compatibility and integration issues — especially with GitOps, AWS/K8s workflows, and Grafana/Prometheus integration. I don’t have extra time to waste dealing with such headaches.

So, I decided to move forward with Envoy + Consul, and the Docker Compose setup went smoothly without any embarrassing issues. This approach avoids the complexity of Nacos, sidesteps its database dependency, and provides a cleaner path for future observability and cloud-native integration.

I also wrote an article for comparing Nacos vs. Consul + Enovy and maybe publish on medium tomorrow . 

https://medium.com/@rurutia1027/service-discovery-and-configuration-mangement-nacos-vs-consul-envoy-7a0242db40e8