### PR TITLE
feat: enable jacoco maven plugin 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,18 @@ jobs:
       - name: Run Tests
         run: mvn test
 
+      - name: Generate JaCoCo Test report
+        run: mvn verify
+
+      - name: Upload All JaCoCo HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: |
+            ./project/target/site/jacoco/
+            ./admin/target/site/jacoco/
+            ./gateway/target/site/jacoco/
+
       # generate a timestamp based unique build number rather than using latest which is hard to distinguish
       - name: Generate Build Number and Save It to File
         id: build-number

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,51 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Plugins for JaCoCo -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <!-- Prepare agent for tests -->
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- Generate report after tests -->
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <!-- Optional: check coverage rules -->
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <!-- todo: increment it later -->
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
in this commit, 
- enable jacoco maven plugin in root pom
- config jacoco configs and add extra steps in ci pipeline to gen Jacoco test repots and upload test reports
Issue: Enable JaCoco to Genearted Test Report and Integrate with GitHub Action CI Stage #67